### PR TITLE
Add Oasis branding: Update custom branding files with Oasis logo and …

### DIFF
--- a/browser/branding/custom/locales/en-US/brand.ftl
+++ b/browser/branding/custom/locales/en-US/brand.ftl
@@ -16,10 +16,10 @@
 ## For further details, consult:
 ## https://mozilla-l10n.github.io/styleguides/mozilla_general/#brands-copyright-and-trademark
 
--brand-shorter-name = Nightly
--brand-short-name = Nightly
--brand-shortcut-name = Nightly
--brand-full-name = Nightly
+-brand-shorter-name = Oasis
+-brand-short-name = Oasis
+-brand-shortcut-name = Oasis
+-brand-full-name = Oasis
 # This brand name can be used in messages where the product name needs to
 # remain unchanged across different versions (Nightly, Beta, etc.).
 -brand-product-name = Firefox

--- a/browser/branding/custom/locales/en-US/brand.properties
+++ b/browser/branding/custom/locales/en-US/brand.properties
@@ -2,6 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-brandShorterName=Nightly
-brandShortName=Nightly
-brandFullName=Nightly
+brandShorterName=Oasis
+brandShortName=Oasis
+brandFullName=Oasis


### PR DESCRIPTION
…text

- Update brand.ftl and brand.properties to use 'Oasis' instead of 'Nightly'
- Add custom Oasis logo (default64.png, default32.png)
- Update firefox-wordmark.svg to display 'Oasis' text
- Configure build to use custom branding directory