### PR TITLE
Transform Firefox Oasis to redirect users to Kahana ecosystem

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1492,7 +1492,7 @@ pref("toolkit.datacollection.infoURL",
 pref("app.support.baseURL", "https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/");
 
 // base url for web-based feedback pages
-pref("app.feedback.baseURL", "https://ideas.mozilla.org/");
+pref("app.feedback.baseURL", "https://kahana.co/oasis-feedback-survey");
 
 pref("security.certerrors.permanentOverride", true);
 pref("security.certerrors.mitm.priming.enabled", true);

--- a/browser/base/content/main-popupset.js
+++ b/browser/base/content/main-popupset.js
@@ -520,6 +520,7 @@ document.addEventListener(
         case "bhTooltip":
           BookmarksEventHandler.fillInBHTooltip(event.target, event);
           break;
+
       }
     });
 

--- a/browser/base/content/navigator-toolbox.inc.xhtml
+++ b/browser/base/content/navigator-toolbox.inc.xhtml
@@ -143,6 +143,7 @@
                      command="Browser:ForwardOrForwardDuplicate"
                      tooltip="forward-button-tooltip"
                      context="backForwardMenu"/>
+
       <toolbaritem id="stop-reload-button" class="chromeclass-toolbar-additional"
                    data-l10n-id="toolbar-button-stop-reload"
                    removable="true" overflows="false">

--- a/browser/base/content/utilityOverlay.js
+++ b/browser/base/content/utilityOverlay.js
@@ -497,7 +497,7 @@ function openTroubleshootingPage() {
  * Opens the feedback page for this version of the application.
  */
 function openFeedbackPage() {
-  var url = Services.urlFormatter.formatURLPref("app.feedback.baseURL");
+  var url = "https://kahana.co/oasis-feedback-survey";
   openTrustedLinkIn(url, "tab");
 }
 

--- a/browser/base/content/webext-panels.xhtml
+++ b/browser/base/content/webext-panels.xhtml
@@ -38,6 +38,7 @@
   <commandset id="mainCommandset">
     <command id="Browser:Stop" disabled="true" />
     <command id="Browser:Reload" disabled="true" />
+
   </commandset>
 
   <popupset id="mainPopupSet">

--- a/browser/components/preferences/home.inc.xhtml
+++ b/browser/components/preferences/home.inc.xhtml
@@ -105,8 +105,8 @@
 
   <html:moz-box-item class="mission-message">
     <html:span data-l10n-id="home-prefs-mission-message" />
-    <html:a is="moz-support-link"
-            support-page="sponsor-privacy"
+    <html:a href="https://kahana.co/docs/sponsor-privacy"
+            target="_blank"
             data-l10n-id="home-prefs-mission-message-learn-more-link" />
   </html:moz-box-item>
 

--- a/browser/components/preferences/main.inc.xhtml
+++ b/browser/components/preferences/main.inc.xhtml
@@ -169,8 +169,8 @@
                   data-l10n-id="browser-containers-enabled"
                   preference="privacy.userContext.enabled"/>
         <html:a
-          is="moz-support-link"
-          support-page="containers"
+          href="https://kahana.co/docs/containers"
+          target="_blank"
           data-l10n-id="browser-containers-learn-more"
         />
         <spacer flex="1"/>
@@ -537,9 +537,9 @@
   <hbox align="center">
     <checkbox id="playDRMContent" preference="media.eme.enabled"
               class="tail-with-learn-more" data-l10n-id="play-drm-content" />
-    <html:a is="moz-support-link"
+    <html:a href="https://kahana.co/docs/drm-content"
+      target="_blank"
       data-l10n-id="play-drm-content-learn-more"
-      support-page="drm-content"
     />
   </hbox>
 </groupbox>
@@ -730,9 +730,9 @@
               class="tail-with-learn-more"
               data-l10n-id="performance-use-recommended-settings-checkbox"
               preference="browser.preferences.defaultPerformanceSettings.enabled"/>
-    <html:a is="moz-support-link"
+    <html:a href="https://kahana.co/docs/performance"
+      target="_blank"
       data-l10n-id="performance-settings-learn-more"
-      support-page="performance"
       />
   </hbox>
   <description class="indent tip-caption" data-l10n-id="performance-use-recommended-settings-desc"/>
@@ -792,9 +792,9 @@
       data-subcategory="netsettings">
     <description flex="1" control="connectionSettings">
       <html:span id="connectionSettingsDescription"/>
-      <html:a is="moz-support-link"
+      <html:a href="https://kahana.co/docs/connection-settings"
             data-l10n-id="network-proxy-connection-learn-more"
-            support-page="prefs-connection-settings"
+            target="_blank"
       />
     </description>
     <separator orient="vertical"/>

--- a/browser/components/preferences/main.js
+++ b/browser/components/preferences/main.js
@@ -365,7 +365,7 @@ let SETTINGS_CONFIG = {
       {
         id: "mediaControlToggleEnabled",
         l10nId: "browsing-media-control",
-        supportPage: "media-keyboard-control",
+        supportPage: "kahana-media-keyboard-control",
       },
       {
         id: "cfrRecommendations",
@@ -402,7 +402,7 @@ let SETTINGS_CONFIG = {
       {
         id: "gpcEnabled",
         l10nId: "global-privacy-control-description",
-        supportPage: "global-privacy-control",
+        supportPage: "kahana-global-privacy-control",
         controlAttrs: {
           "search-l10n-ids": "global-privacy-control-search",
         },

--- a/browser/components/preferences/moreFromMozilla.js
+++ b/browser/components/preferences/moreFromMozilla.js
@@ -91,9 +91,7 @@ var gMoreFromMozillaPane = {
           id: "fxMobile",
           type: "link",
           label_string_id: "more-from-moz-learn-more-link",
-          actionURL: BrowserUtils.isChinaRepack()
-            ? "https://www.firefox.com.cn/browsers/mobile/"
-            : "https://www.mozilla.org/firefox/browsers/mobile/",
+          actionURL: "https://kahana.co/oasis-mobile",
         },
         qrcode: {
           title: {
@@ -106,9 +104,7 @@ var gMoreFromMozillaPane = {
             label: {
               string_id: "more-from-moz-qr-code-box-firefox-mobile-button",
             },
-            actionURL: BrowserUtils.isChinaRepack()
-              ? "https://www.firefox.com.cn/mobile/get-app/"
-              : "https://www.mozilla.org/firefox/mobile/get-app/?v=mfm",
+            actionURL: "https://kahana.co/oasis-mobile",
           },
         },
       },
@@ -122,7 +118,7 @@ var gMoreFromMozillaPane = {
         button: {
           id: "mozillaMonitor",
           label_string_id: "more-from-moz-mozilla-monitor-button",
-          actionURL: "https://monitor.mozilla.org/",
+          actionURL: "https://kahana.co/schedule-demo",
         },
       },
     ];
@@ -136,7 +132,7 @@ var gMoreFromMozillaPane = {
         button: {
           id: "mozillaVPN",
           label_string_id: "more-from-moz-button-mozilla-vpn-2",
-          actionURL: "https://www.mozilla.org/products/vpn/",
+          actionURL: "https://kahana.co/sales",
         },
       };
       products.push(vpn);
@@ -151,7 +147,7 @@ var gMoreFromMozillaPane = {
         button: {
           id: "firefoxRelay",
           label_string_id: "more-from-moz-firefox-relay-button",
-          actionURL: "https://relay.firefox.com/",
+          actionURL: "https://kahana.co/oasis-augmented-reality",
         },
       };
       products.push(relay);
@@ -165,7 +161,7 @@ var gMoreFromMozillaPane = {
       button: {
         id: "soloAI",
         label_string_id: "more-from-moz-solo-button",
-        actionURL: "https://soloist.ai/?utm_type=more_from_mozilla",
+        actionURL: "https://kahana.co/community",
       },
     });
 
@@ -177,7 +173,7 @@ var gMoreFromMozillaPane = {
       button: {
         id: "mdn",
         label_string_id: "more-from-moz-mdn-button",
-        actionURL: "https://developer.mozilla.org/docs/Learn_web_development",
+        actionURL: "https://kahana.co/products/enterprise-browser",
       },
     });
 

--- a/browser/components/preferences/preferences.xhtml
+++ b/browser/components/preferences/preferences.xhtml
@@ -206,7 +206,7 @@
           <label class="sidebar-footer-label" flex="1" data-l10n-id="addons-button-label"></label>
         </html:a>
         <html:a id="helpButton" class="sidebar-footer-link" target="_blank"
-                is="moz-support-link" support-page="preferences">
+                href="https://kahana.co/docs">
           <image class="sidebar-footer-icon help-icon"/>
           <label class="sidebar-footer-label" flex="1" data-l10n-id="help-button-label"></label>
         </html:a>

--- a/browser/components/preferences/privacy.inc.xhtml
+++ b/browser/components/preferences/privacy.inc.xhtml
@@ -22,11 +22,11 @@
       <image id="trackingProtectionShield"/>
       <description class="description-with-side-element" flex="1">
         <html:span id="contentBlockingDescription" data-l10n-id="content-blocking-section-top-level-description"></html:span>
-        <html:a is="moz-support-link"
+        <html:a href="https://kahana.co/docs/enhanced-tracking-protection"
                 id="contentBlockingLearnMore"
                 class="learnMore"
                 data-l10n-id="content-blocking-learn-more"
-                support-page="enhanced-tracking-protection"
+                target="_blank"
         />
       </description>
       <button id="trackingProtectionExceptions"
@@ -50,9 +50,9 @@
       <vbox flex="1">
         <description>
           <html:span data-l10n-id="content-blocking-rfp-incompatibility-warning"/>
-          <html:a is="moz-support-link"
+          <html:a href="https://kahana.co/docs/resist-fingerprinting"
                   class="learnMore"
-                  support-page="resist-fingerprinting"
+                  target="_blank"
           />
         </description>
       </vbox>
@@ -129,11 +129,11 @@
                 <label class="content-blocking-warning-title" data-l10n-id="content-blocking-etp-standard-tcp-title"/>
                 <description>
                   <html:span data-l10n-id="content-blocking-etp-standard-tcp-rollout-description"></html:span>
-                  <html:a is="moz-support-link"
+                  <html:a href="https://kahana.co/docs/total-cookie-protection"
                           id="tcp-learn-more-link"
                           class="learnMore"
                           data-l10n-id="content-blocking-etp-standard-tcp-rollout-learn-more"
-                          support-page="total-cookie-protection"
+                          target="_blank"
                   />
                 </description>
               </vbox>
@@ -242,7 +242,7 @@
                   <html:a is="moz-support-link"
                           class="learnMore"
                           data-l10n-id="content-blocking-warning-learn-how"
-                          support-page="turn-off-etp-desktop"
+                          href="https://kahana.co/docs/enhanced-tracking-protection" target="_blank"
                   />
                 </description>
               </vbox>
@@ -370,7 +370,7 @@
                   <html:a is="moz-support-link"
                           class="learnMore"
                           data-l10n-id="content-blocking-warning-learn-how"
-                          support-page="turn-off-etp-desktop"
+                          href="https://kahana.co/docs/enhanced-tracking-protection" target="_blank"
                   />
                 </description>
               </vbox>
@@ -394,10 +394,10 @@
     <vbox flex="1">
       <description class="description-with-side-element description-deemphasized" flex="1">
         <html:span id="totalSiteDataSize"></html:span>
-        <html:a is="moz-support-link"
+        <html:a href="https://kahana.co/docs/storage-permissions"
                 id="siteDataLearnMoreLink"
                 data-l10n-id="sitedata-learn-more"
-                support-page="storage-permissions"
+                target="_blank"
         />
       </description>
       <hbox flex="1" id="deleteOnCloseNote" class="info-box-container smaller-font-size">
@@ -536,10 +536,10 @@
                 class="tail-with-learn-more"
                 data-l10n-id="forms-breach-alerts"
                 preference="signon.management.page.breach-alerts.enabled"/>
-      <html:a is="moz-support-link"
+      <html:a href="https://kahana.co/docs/lockwise-alerts"
               id="breachAlertsLearnMoreLink"
               data-l10n-id="forms-breach-alerts-learn-more-link"
-              support-page="lockwise-alerts"
+              target="_blank"
       />
     </hbox>
   </vbox>
@@ -554,10 +554,10 @@
       <checkbox id="useMasterPassword"
                 data-l10n-id="forms-primary-pw-use"
                 class="tail-with-learn-more"/>
-      <html:a is="moz-support-link"
+      <html:a href="https://kahana.co/docs/primary-password"
               id="primaryPasswordLearnMoreLink"
               data-l10n-id="forms-primary-pw-learn-more-link"
-              support-page="primary-password-stored-logins"
+              target="_blank"
       />
       <spacer flex="1"/>
       <button id="changeMasterPassword"
@@ -840,11 +840,11 @@
         <label id="notificationPermissionsLabel"
                class="tail-with-learn-more"
                data-l10n-id="permissions-notification"/>
-        <html:a is="moz-support-link"
+        <html:a href="https://kahana.co/docs/notifications"
                 id="notificationPermissionsLearnMore"
                 class="learnMore"
                 data-l10n-id="permissions-notification-link"
-                support-page="push"
+                target="_blank"
         />
       </hbox>
       <hbox pack="end">
@@ -982,10 +982,10 @@
     <description>
       <html:span id="telemetryDisabledDescription"
                  data-l10n-id="collection-health-report-telemetry-disabled"/>
-      <html:a is="moz-support-link"
-              support-page="telemetry-clientid"
+      <html:a href="https://kahana.co/docs/technical-and-interaction-data"
               class="learnMore"
-              data-l10n-id="collection-health-report-telemetry-disabled-link"/>
+              data-l10n-id="collection-health-report-telemetry-disabled-link"
+              target="_blank"/>
     </description>
   </hbox>
 
@@ -999,10 +999,10 @@
       <html:span data-l10n-id="collection-health-report-disabled2"/>
 #endif # MOZ_TELEMETRY_REPORTING
       <html:a id="FHRLearnMore"
-              is="moz-support-link"
-              support-page="technical-and-interaction-data"
+              href="https://kahana.co/docs/technical-and-interaction-data"
               class="learnMore"
-              data-l10n-id="collection-health-report-link"/>
+              data-l10n-id="collection-health-report-link"
+              target="_blank"/>
     </description>
 
     <vbox class="indent">
@@ -1010,10 +1010,10 @@
                 data-l10n-id="addon-recommendations2"/>
       <description class="indent tip-caption">
         <html:span data-l10n-id="addon-recommendations-description"/>
-        <html:a is="moz-support-link"
+        <html:a href="https://kahana.co/docs/extension-recommendations"
                 id="addonRecommendationLearnMore"
                 class="learnMore"
-                support-page="personalized-addons"/>
+                target="_blank"/>
       </description>
 
 #ifdef MOZ_NORMANDY
@@ -1036,9 +1036,9 @@
     <description class="indent tip-caption">
       <html:span data-l10n-id="collection-usage-ping-description"/>
       <html:a id="submitUsagePingLearnMore"
-              is="moz-support-link"
+              href="https://kahana.co/docs/usage-ping-settings"
               class="learnMore"
-              support-page="usage-ping-settings"/>
+              target="_blank"/>
     </description>
 
 #ifdef MOZ_CRASHREPORTER
@@ -1047,9 +1047,9 @@
               preference="browser.crashReports.unsubmittedCheck.autoSubmit2"/>
     <description class="indent tip-caption">
       <html:span data-l10n-id="collection-backlogged-crash-reports-description"/>
-      <html:a is="moz-support-link"
+      <html:a href="https://kahana.co/docs/crash-report"
               class="learnMore"
-              support-page="crash-reports"
+              target="_blank"
               id="crashReporterLearnMore"/>
     </description>
 #endif # MOZ_CRASHREPORTER
@@ -1060,7 +1060,7 @@
                    preference="browser.urlbar.quicksuggest.dataCollection.enabled"
                    data-l10n-id="addressbar-firefox-suggest-data-collection"
                    data-l10n-attrs="label, description"
-                   support-page="firefox-suggest#w_what-setting-is-opt-in"
+                   support-page="kahana-improve-oasis-suggest"
   />
   <vbox id="privacySegmentationSection" data-subcategory="privacy-segmentation" hidden="true">
     <label>
@@ -1227,10 +1227,10 @@
   <vbox id="dohStatusSection" class="privacy-detailedoption info-box-container">
     <hbox>
       <label id="dohStatus" class="doh-status-label tail-with-learn-more"/>
-      <html:a is="moz-support-link"
+      <html:a href="https://kahana.co/docs/dns-over-https"
             id="dohStatusLearnMore"
             class="learnMore"
-            support-page="doh-status"
+            target="_blank"
             hidden="true"/>
     </hbox>
     <label class="doh-status-label" id="dohResolver"/>
@@ -1288,10 +1288,10 @@
                 </hbox>
                 <hbox class="extra-information-label">
                   <label class="doh-label tail-with-learn-more" data-l10n-id="preferences-doh-default-detailed-desc-5"/>
-                  <html:a is="moz-support-link"
+                  <html:a href="https://kahana.co/docs/default-protection"
                           id="default-desc-5-learn-more"
                           class="learnMore"
-                          support-page="firefox-turn-off-secure-dns"
+                          target="_blank"
                   />
                 </hbox>
               </vbox>

--- a/browser/components/preferences/search.inc.xhtml
+++ b/browser/components/preferences/search.inc.xhtml
@@ -54,7 +54,7 @@
                   data-l10n-id="search-show-suggestions-private-windows"/>
         <hbox align="center" id="showTrendingSuggestionsBox">
           <checkbox id="showTrendingSuggestions" data-l10n-id="addressbar-locbar-showtrendingsuggestions-option" preference="browser.urlbar.suggest.trending" class="tail-with-learn-more" />
-          <html:a is="moz-support-link" support-page="google-trending-searches-on-awesomebar" />
+          <html:a href="https://kahana.co/docs/google-trending-search-firefox-address-bar" target="_blank" />
         </hbox>
         <hbox id="urlBarSuggestionPermanentPBLabel"
               align="center" class="indent">
@@ -77,11 +77,11 @@
                    data-l10n-id="addressbar-suggest"
         />
         <html:a hidden="true"
-                is="moz-support-link"
+                href="https://kahana.co/docs/oasis-suggest"
                 id="firefoxSuggestLearnMore"
                 class="learnMore firefoxSuggestLearnMore"
                 data-l10n-id="addressbar-locbar-firefox-suggest-learn-more"
-                support-page="firefox-suggest"
+                target="_blank"
         />
       </description>
       <checkbox id="historySuggestion" data-l10n-id="addressbar-locbar-history-option"
@@ -102,10 +102,10 @@
                   class="tail-with-learn-more"
                   data-l10n-id="addressbar-locbar-quickactions-option"
                   preference="browser.urlbar.suggest.quickactions" />
-        <html:a is="moz-support-link"
+        <html:a href="https://kahana.co/docs/quick-actions"
                 id="quickActionsLink"
                 data-l10n-id="addressbar-quickactions-learn-more"
-                support-page="quick-actions-firefox-search-bar"
+                target="_blank"
         />
       </hbox>
       <vbox id="firefoxSuggestContainer" hidden="true">
@@ -127,7 +127,7 @@
                          preference="browser.urlbar.quicksuggest.dataCollection.enabled"
                          data-l10n-id="addressbar-firefox-suggest-data-collection"
                          data-l10n-attrs="label, description"
-                         support-page="firefox-suggest#w_what-setting-is-opt-in"
+                         support-page="kahana-improve-oasis-suggest"
         />
         <hbox id="dismissedSuggestions" align="center">
           <vbox flex="1">

--- a/browser/extensions/newtab/data/content/activity-stream.bundle.js
+++ b/browser/extensions/newtab/data/content/activity-stream.bundle.js
@@ -15401,9 +15401,9 @@ class _Weather extends (external_React_default()).PureComponent {
       onUpdate: this.onUpdate,
       options: contextOpts,
       site: {
-        url: "https://support.mozilla.org/kb/customize-items-on-firefox-new-tab-page"
+        url: "https://kahana.co/docs/weather-customization"
       },
-      link: "https://support.mozilla.org/kb/customize-items-on-firefox-new-tab-page",
+      link: "https://kahana.co/docs/weather-customization",
       shouldSendImpressionStats: false
     }) : null));
     if (Weather.searchActive) {

--- a/browser/locales/en-US/browser/preferences/moreFromMozilla.ftl
+++ b/browser/locales/en-US/browser/preferences/moreFromMozilla.ftl
@@ -43,10 +43,10 @@ more-from-moz-mozilla-monitor-button = Schedule Demo
 
 more-from-moz-solo-title = { -solo-ai-brand-name } AI
 more-from-moz-solo-description = Create your website instantly and connect your own custom domain for free.
-more-from-moz-solo-button = Try { -solo-ai-brand-name }
+more-from-moz-solo-button = Join Discord
 
 ## These strings are for the MDN card in about:preferences moreFromMozilla page
 
 more-from-moz-mdn-title = MDN Web Docs
 more-from-moz-mdn-description = Learn web development with free, comprehensive guides and references.
-more-from-moz-mdn-button = Learn web development
+more-from-moz-mdn-button = Oasis Enterprise Browser

--- a/browser/locales/en-US/browser/sidebar.ftl
+++ b/browser/locales/en-US/browser/sidebar.ftl
@@ -11,6 +11,8 @@ menu-view-contextual-password-manager =
 sidebar-options-menu-button =
   .title = Open menu
 
+
+
 ## Labels for sidebar history panel
 
 # Variables:

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -3027,7 +3027,7 @@ pref("signon.includeOtherSubdomainsInLookup",     true);
 pref("signon.masterPasswordReprompt.timeout_ms", 900000); // 15 Minutes
 pref("signon.showAutoCompleteFooter",             false);
 pref("signon.firefoxRelay.base_url", "https://relay.firefox.com/api/v1/");
-pref("signon.firefoxRelay.learn_more_url", "https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/firefox-relay-integration");
+pref("signon.firefoxRelay.learn_more_url", "https://kahana.co/docs/firefox-relay-integration");
 pref("signon.firefoxRelay.manage_url", "https://relay.firefox.com/accounts/profile/?utm_medium=firefox-desktop&utm_source=modal&utm_campaign=limit&utm_content=manage-masks-global");
 pref("signon.firefoxRelay.terms_of_service_url", "https://www.mozilla.org/%LOCALE%/about/legal/terms/subscription-services/");
 pref("signon.firefoxRelay.privacy_policy_url", "https://www.mozilla.org/%LOCALE%/privacy/subscription-services/");

--- a/toolkit/components/formautofill/FormAutofillPreferences.sys.mjs
+++ b/toolkit/components/formautofill/FormAutofillPreferences.sys.mjs
@@ -107,9 +107,7 @@ FormAutofillPreferences.prototype = {
       let addressAutofill = document.createXULElement("hbox");
       let addressAutofillCheckboxGroup = document.createXULElement("hbox");
       let addressAutofillCheckbox = document.createXULElement("checkbox");
-      let addressAutofillLearnMore = document.createElement("a", {
-        is: "moz-support-link",
-      });
+      let addressAutofillLearnMore = document.createElement("a");
       let savedAddressesBtn = document.createXULElement("button", {
         is: "highlightable-button",
       });
@@ -134,8 +132,12 @@ FormAutofillPreferences.prototype = {
       savedAddressesBtnWrapper.setAttribute("align", "start");
 
       addressAutofillLearnMore.setAttribute(
-        "support-page",
-        "autofill-card-address"
+        "href",
+        "https://kahana.co/docs/autofill"
+      );
+      addressAutofillLearnMore.setAttribute(
+        "target",
+        "_blank"
       );
 
       // Add preferences search support
@@ -172,9 +174,7 @@ FormAutofillPreferences.prototype = {
       let creditCardAutofill = document.createXULElement("hbox");
       let creditCardAutofillCheckboxGroup = document.createXULElement("hbox");
       let creditCardAutofillCheckbox = document.createXULElement("checkbox");
-      let creditCardAutofillLearnMore = document.createElement("a", {
-        is: "moz-support-link",
-      });
+      let creditCardAutofillLearnMore = document.createElement("a");
       let savedCreditCardsBtn = document.createXULElement("button", {
         is: "highlightable-button",
       });
@@ -202,8 +202,12 @@ FormAutofillPreferences.prototype = {
       savedCreditCardsBtnWrapper.setAttribute("align", "start");
 
       creditCardAutofillLearnMore.setAttribute(
-        "support-page",
-        "credit-card-autofill"
+        "href",
+        "https://kahana.co/docs/payment-methods"
+      );
+      creditCardAutofillLearnMore.setAttribute(
+        "target",
+        "_blank"
       );
 
       let creditCardsAutofillDescription =
@@ -252,9 +256,7 @@ FormAutofillPreferences.prototype = {
         let reauth = document.createXULElement("hbox");
         let reauthCheckboxGroup = document.createXULElement("hbox");
         let reauthCheckbox = document.createXULElement("checkbox");
-        let reauthLearnMore = document.createElement("a", {
-          is: "moz-support-link",
-        });
+        let reauthLearnMore = document.createElement("a");
 
         reauthCheckboxGroup.classList.add("indent");
         reauthCheckbox.classList.add("tail-with-learn-more");
@@ -277,8 +279,12 @@ FormAutofillPreferences.prototype = {
         );
 
         reauthLearnMore.setAttribute(
-          "support-page",
-          "credit-card-autofill#w_require-authentication-for-autofill"
+          "href",
+          "https://kahana.co/docs/autofill"
+        );
+        reauthLearnMore.setAttribute(
+          "target",
+          "_blank"
         );
 
         reauthCheckboxGroup.setAttribute("align", "center");

--- a/toolkit/components/pictureinpicture/content/pictureInPicturePanel.inc.xhtml
+++ b/toolkit/components/pictureinpicture/content/pictureInPicturePanel.inc.xhtml
@@ -25,9 +25,9 @@
           data-l10n-id="picture-in-picture-panel-body"
         />
         <html:a
-          is="moz-support-link"
+          href="https://kahana.co/docs/picture-in-picture"
+          target="_blank"
           id="pip-learn-more-link"
-          support-page="about-picture-picture-firefox"
         />
       </html:div>
     </vbox>

--- a/toolkit/content/widgets/moz-support-link/moz-support-link.mjs
+++ b/toolkit/content/widgets/moz-support-link/moz-support-link.mjs
@@ -102,6 +102,23 @@ export default class MozSupportLink extends HTMLAnchorElement {
 
   #setHref() {
     let supportPage = this.getAttribute("support-page") ?? "";
+    
+    // Handle custom Kahana support pages
+    if (supportPage === "kahana-media-keyboard-control") {
+      this.href = "https://kahana.co/docs/media-keyboard-control";
+      return;
+    }
+    
+    if (supportPage === "kahana-improve-oasis-suggest") {
+      this.href = "https://kahana.co/docs/improve-oasis-suggest";
+      return;
+    }
+    
+    if (supportPage === "kahana-global-privacy-control") {
+      this.href = "https://kahana.co/docs/global-privacy-control";
+      return;
+    }
+    
     let base = MozSupportLink.SUPPORT_URL + supportPage;
     this.href = this.hasAttribute("utm-content")
       ? formatUTMParams(this.getAttribute("utm-content"), base)


### PR DESCRIPTION
- Update 45+ documentation links from Mozilla Support to Kahana docs
- Replace 'Share Ideas and Feedback' link with Kahana feedback survey
- Update 'More from Mozilla' section to point to Kahana services
- Change button labels: 'Try Solo' → 'Join Discord', 'Learn Web Development' → 'Oasis Enterprise Browser'
- Update all privacy, security, and performance documentation links
- Update autofill and form-related documentation links
- Update Oasis Support help button to point to Kahana docs
- Remove custom sidebar toggle button (using existing Firefox sidebar button)
- Hardcode feedback URL to ensure changes take effect

This transforms the browser from Mozilla's ecosystem to Kahana's ecosystem, ensuring users get support and documentation from your platform instead of Mozilla's.